### PR TITLE
Implements #2: Filter by minimum vegType

### DIFF
--- a/VegSailor.pro
+++ b/VegSailor.pro
@@ -39,6 +39,8 @@ OTHER_FILES += \
     pyveggiesailor/vegguide_cache.py \
     qml/pages/EntryMap.qml \
     qml/pages/EntryBackgroundItem.qml \
+    qml/pages/ChooseMinimumVegLevel.qml \
+    qml/VegLevel.js
 
 
 # to disable building translations every time, comment out the

--- a/qml/VegLevel.js
+++ b/qml/VegLevel.js
@@ -1,0 +1,9 @@
+// VegLevel enum
+var VegLevel =  [
+    qsTr("Show all"),
+    qsTr("Vegetarian-Friendly"),
+    qsTr("Vegan-Friendly"),
+    qsTr("Vegetarian (But Not Vegan-Friendly)"),
+    qsTr("Vegetarian"),
+    qsTr("Vegan")
+];

--- a/qml/harbour-veggiesailor.qml
+++ b/qml/harbour-veggiesailor.qml
@@ -34,6 +34,11 @@ import "pages"
 
 ApplicationWindow
 {
+    // Current state properties:
+    property int minimumVegLevel : 0
+
+
+
     initialPage: Component { FirstPage { } }
     cover: Qt.resolvedUrl("cover/CoverPage.qml")
 }

--- a/qml/pages/ChooseMinimumVegLevel.qml
+++ b/qml/pages/ChooseMinimumVegLevel.qml
@@ -1,0 +1,62 @@
+import QtQuick 2.0
+import Sailfish.Silica 1.0
+import "../VegLevel.js" as VegLevel
+
+Page {
+SilicaListView {
+    anchors.fill: parent
+
+    model: ListModel {
+        id: listModel
+        ListElement {
+            level: 0
+        }
+        ListElement {
+            level: 1
+        }
+        ListElement {
+            level: 2
+        }
+        // Does not include minimum level 3 - Vegetarian (But Not Vegan-Friendly)
+        // to keep it simple. All level 3 entries are also included when choosing 2.
+        ListElement {
+            level: 4
+        }
+        ListElement {
+            level: 5
+        }
+    }
+    header: PageHeader {
+        title: qsTr("Minium Veggie-Level")
+    }
+
+    delegate: BackgroundItem {
+        height: Theme.itemSizeMedium
+        anchors {
+            left: parent.left
+            right: parent.right
+        }
+
+        Label {
+            anchors {
+                left: parent.left
+                leftMargin: Theme.paddingLarge
+                right: parent.right
+                rightMargin: Theme.paddingSmall
+                verticalCenter: parent.verticalCenter
+            }
+            text: VegLevel.VegLevel[level]
+            color: highlighted ? Theme.highlightColor : Theme.primaryColor
+
+        }
+
+
+
+        onClicked: {
+            minimumVegLevel = level
+            pageStack.pop()
+        }
+
+    }
+}
+}

--- a/qml/pages/Entries.qml
+++ b/qml/pages/Entries.qml
@@ -1,7 +1,7 @@
 import QtQuick 2.0
 import Sailfish.Silica 1.0
 import io.thp.pyotherside 1.3
-
+import "../VegLevel.js" as VegLevel
 Page {
     id: page
 
@@ -12,6 +12,7 @@ Page {
     property string color
 
     property bool loadingData
+    property var entries : null
 
 
     SilicaListView {
@@ -37,12 +38,22 @@ Page {
                     }
                 }
             }
+            MenuItem {
+                id: minimumVegLevelMenu
+                text: qsTr("Minimum Veggie-Level")
+
+                onClicked:
+                {
+                    onClicked: pageStack.push(Qt.resolvedUrl("ChooseMinimumVegLevel.qml"))
+                }
+            }
         }
         model: ListModel {
             id: listModel
         }
         header: PageHeader {
             title: qsTr(page.mytext)
+            description: minimumVegLevel == 0 ? "" : qsTr("At least %1").arg(VegLevel.VegLevel[minimumVegLevel])
         }
         delegate: BackgroundItem {
             height: Theme.itemSizeMedium
@@ -139,7 +150,7 @@ Page {
     }
     Python {
         id: py
-        Component.onCompleted: {
+        function loadData() {
             addImportPath(Qt.resolvedUrl('../..'));
             importModule('pyveggiesailor.controller', function () {
                 loadingData = true;
@@ -152,15 +163,36 @@ Page {
                         favorite.text = "Add to favorites";
                     }
                 });
-                py.call('pyveggiesailor.controller.get_entries', [page.uri], function(result) {
-                    for (var i=0; i<result.length; i++) {
-                        listModel.append(result[i]);
-                    }
+                if(entries == null) {
+                    py.call('pyveggiesailor.controller.get_entries', [page.uri], function(result) {
+                        entries = result;
+                        showEntries(result);
+                    });
+                } else {
+                     showEntries(entries);
+                }
 
-                    loadingData = false;
-                });
+
             });
         }
     }
+
+    function showEntries(entries) {
+        loadingData = false;
+        listModel.clear();
+        for (var i=0; i<entries.length; i++) {
+            if(entries[i].veg_level >= minimumVegLevel) {
+                listModel.append(entries[i]);
+            }
+
+        }
+
+    }
+
+    onStatusChanged: {
+        if (status === PageStatus.Active) {
+            py.loadData();
+        }
+     }
 
 }

--- a/translations/harbour-veggiesailor-de.ts
+++ b/translations/harbour-veggiesailor-de.ts
@@ -2,6 +2,14 @@
 <!DOCTYPE TS>
 <TS version="2.1">
 <context>
+    <name>ChooseMinimumVegLevel</name>
+    <message>
+        <location filename="../qml/pages/ChooseMinimumVegLevel.qml" line="30"/>
+        <source>Minium Veggie-Level</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>CoverPage</name>
     <message>
         <location filename="../qml/cover/CoverPage.qml" line="37"/>
@@ -30,18 +38,28 @@
 <context>
     <name>Entries</name>
     <message>
-        <location filename="../qml/pages/Entries.qml" line="22"/>
-        <location filename="../qml/pages/Entries.qml" line="34"/>
+        <location filename="../qml/pages/Entries.qml" line="23"/>
+        <location filename="../qml/pages/Entries.qml" line="35"/>
         <source>Add to favorites</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/pages/Entries.qml" line="30"/>
+        <location filename="../qml/pages/Entries.qml" line="31"/>
         <source>Remove from favorites</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/pages/Entries.qml" line="115"/>
+        <location filename="../qml/pages/Entries.qml" line="43"/>
+        <source>Minimum Veggie-Level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/Entries.qml" line="56"/>
+        <source>At least %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/Entries.qml" line="126"/>
         <source>Unknown</source>
         <translation type="unfinished"></translation>
     </message>
@@ -155,6 +173,39 @@
     <message>
         <location filename="../qml/pages/PlaceInfo.qml" line="158"/>
         <source>Tags</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>VegLevel</name>
+    <message>
+        <location filename="../qml/VegLevel.js" line="3"/>
+        <source>Show all</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/VegLevel.js" line="4"/>
+        <source>Vegetarian-Friendly</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/VegLevel.js" line="5"/>
+        <source>Vegan-Friendly</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/VegLevel.js" line="6"/>
+        <source>Vegetarian (But Not Vegan-Friendly)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/VegLevel.js" line="7"/>
+        <source>Vegetarian</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/VegLevel.js" line="8"/>
+        <source>Vegan</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/harbour-veggiesailor-es.ts
+++ b/translations/harbour-veggiesailor-es.ts
@@ -2,6 +2,14 @@
 <!DOCTYPE TS>
 <TS version="2.1">
 <context>
+    <name>ChooseMinimumVegLevel</name>
+    <message>
+        <location filename="../qml/pages/ChooseMinimumVegLevel.qml" line="30"/>
+        <source>Minium Veggie-Level</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>CoverPage</name>
     <message>
         <location filename="../qml/cover/CoverPage.qml" line="37"/>
@@ -30,18 +38,28 @@
 <context>
     <name>Entries</name>
     <message>
-        <location filename="../qml/pages/Entries.qml" line="22"/>
-        <location filename="../qml/pages/Entries.qml" line="34"/>
+        <location filename="../qml/pages/Entries.qml" line="23"/>
+        <location filename="../qml/pages/Entries.qml" line="35"/>
         <source>Add to favorites</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/pages/Entries.qml" line="30"/>
+        <location filename="../qml/pages/Entries.qml" line="31"/>
         <source>Remove from favorites</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/pages/Entries.qml" line="115"/>
+        <location filename="../qml/pages/Entries.qml" line="43"/>
+        <source>Minimum Veggie-Level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/Entries.qml" line="56"/>
+        <source>At least %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/Entries.qml" line="126"/>
         <source>Unknown</source>
         <translation type="unfinished"></translation>
     </message>
@@ -155,6 +173,39 @@
     <message>
         <location filename="../qml/pages/PlaceInfo.qml" line="158"/>
         <source>Tags</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>VegLevel</name>
+    <message>
+        <location filename="../qml/VegLevel.js" line="3"/>
+        <source>Show all</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/VegLevel.js" line="4"/>
+        <source>Vegetarian-Friendly</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/VegLevel.js" line="5"/>
+        <source>Vegan-Friendly</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/VegLevel.js" line="6"/>
+        <source>Vegetarian (But Not Vegan-Friendly)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/VegLevel.js" line="7"/>
+        <source>Vegetarian</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/VegLevel.js" line="8"/>
+        <source>Vegan</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/harbour-veggiesailor-fr.ts
+++ b/translations/harbour-veggiesailor-fr.ts
@@ -2,6 +2,14 @@
 <!DOCTYPE TS>
 <TS version="2.1">
 <context>
+    <name>ChooseMinimumVegLevel</name>
+    <message>
+        <location filename="../qml/pages/ChooseMinimumVegLevel.qml" line="30"/>
+        <source>Minium Veggie-Level</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>CoverPage</name>
     <message>
         <location filename="../qml/cover/CoverPage.qml" line="37"/>
@@ -30,18 +38,28 @@
 <context>
     <name>Entries</name>
     <message>
-        <location filename="../qml/pages/Entries.qml" line="22"/>
-        <location filename="../qml/pages/Entries.qml" line="34"/>
+        <location filename="../qml/pages/Entries.qml" line="23"/>
+        <location filename="../qml/pages/Entries.qml" line="35"/>
         <source>Add to favorites</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/pages/Entries.qml" line="30"/>
+        <location filename="../qml/pages/Entries.qml" line="31"/>
         <source>Remove from favorites</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/pages/Entries.qml" line="115"/>
+        <location filename="../qml/pages/Entries.qml" line="43"/>
+        <source>Minimum Veggie-Level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/Entries.qml" line="56"/>
+        <source>At least %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/Entries.qml" line="126"/>
         <source>Unknown</source>
         <translation type="unfinished"></translation>
     </message>
@@ -155,6 +173,39 @@
     <message>
         <location filename="../qml/pages/PlaceInfo.qml" line="158"/>
         <source>Tags</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>VegLevel</name>
+    <message>
+        <location filename="../qml/VegLevel.js" line="3"/>
+        <source>Show all</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/VegLevel.js" line="4"/>
+        <source>Vegetarian-Friendly</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/VegLevel.js" line="5"/>
+        <source>Vegan-Friendly</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/VegLevel.js" line="6"/>
+        <source>Vegetarian (But Not Vegan-Friendly)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/VegLevel.js" line="7"/>
+        <source>Vegetarian</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/VegLevel.js" line="8"/>
+        <source>Vegan</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/harbour-veggiesailor.ts
+++ b/translations/harbour-veggiesailor.ts
@@ -2,6 +2,14 @@
 <!DOCTYPE TS>
 <TS version="2.1">
 <context>
+    <name>ChooseMinimumVegLevel</name>
+    <message>
+        <location filename="../qml/pages/ChooseMinimumVegLevel.qml" line="30"/>
+        <source>Minium Veggie-Level</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>CoverPage</name>
     <message>
         <location filename="../qml/cover/CoverPage.qml" line="37"/>
@@ -30,18 +38,28 @@
 <context>
     <name>Entries</name>
     <message>
-        <location filename="../qml/pages/Entries.qml" line="22"/>
-        <location filename="../qml/pages/Entries.qml" line="34"/>
+        <location filename="../qml/pages/Entries.qml" line="23"/>
+        <location filename="../qml/pages/Entries.qml" line="35"/>
         <source>Add to favorites</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/pages/Entries.qml" line="30"/>
+        <location filename="../qml/pages/Entries.qml" line="31"/>
         <source>Remove from favorites</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/pages/Entries.qml" line="115"/>
+        <location filename="../qml/pages/Entries.qml" line="43"/>
+        <source>Minimum Veggie-Level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/Entries.qml" line="56"/>
+        <source>At least %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/Entries.qml" line="126"/>
         <source>Unknown</source>
         <translation type="unfinished"></translation>
     </message>
@@ -155,6 +173,39 @@
     <message>
         <location filename="../qml/pages/PlaceInfo.qml" line="158"/>
         <source>Tags</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>VegLevel</name>
+    <message>
+        <location filename="../qml/VegLevel.js" line="3"/>
+        <source>Show all</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/VegLevel.js" line="4"/>
+        <source>Vegetarian-Friendly</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/VegLevel.js" line="5"/>
+        <source>Vegan-Friendly</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/VegLevel.js" line="6"/>
+        <source>Vegetarian (But Not Vegan-Friendly)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/VegLevel.js" line="7"/>
+        <source>Vegetarian</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/VegLevel.js" line="8"/>
+        <source>Vegan</source>
         <translation type="unfinished"></translation>
     </message>
 </context>


### PR DESCRIPTION
Adds a pulleymenu entry to entries page which allows filtering based on veggie type.
When a filter is applied (for example 'vegetarian'), only entries at least vegetarian are shown.
